### PR TITLE
Move downloading of grafana to a separate script

### DIFF
--- a/grafana/Dockerfile.template
+++ b/grafana/Dockerfile.template
@@ -11,11 +11,8 @@ RUN install_packages \
       libfontconfig1 \
       ucf
 
-RUN if [ "%%BALENA_MACHINE_NAME%%" = "raspberry-pi" ]; then \
-    curl -o /tmp/grafana.deb https://dl.grafana.com/oss/release/grafana-rpi_6.1.4_armhf.deb; \
-  else \
-    curl -o /tmp/grafana.deb https://dl.grafana.com/oss/release/grafana_6.1.4_armhf.deb; \
-  fi
+COPY ./download.sh /usr/src/app/download.sh
+RUN /usr/src/app/download.sh "%%BALENA_MACHINE_NAME%%"
 
 RUN dpkg -i /tmp/grafana.deb && rm /tmp/grafana.deb
 

--- a/grafana/download.sh
+++ b/grafana/download.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$1" = "raspberry-pi" ]; then
+	curl -o /tmp/grafana.deb https://dl.grafana.com/oss/release/grafana-rpi_6.1.4_armhf.deb;
+else
+	curl -o /tmp/grafana.deb https://dl.grafana.com/oss/release/grafana_6.1.4_armhf.deb;
+fi


### PR DESCRIPTION
This mitigates a CLI issue that causes the build to fail under emulation.

Change-type: patch