### PR TITLE
execution fix for grafana

### DIFF
--- a/grafana/Dockerfile.template
+++ b/grafana/Dockerfile.template
@@ -12,7 +12,7 @@ RUN install_packages \
       ucf
 
 COPY ./download.sh /usr/src/app/download.sh
-RUN /usr/src/app/download.sh "%%BALENA_MACHINE_NAME%%"
+RUN sh /usr/src/app/download.sh "%%BALENA_MACHINE_NAME%%"
 
 RUN dpkg -i /tmp/grafana.deb && rm /tmp/grafana.deb
 


### PR DESCRIPTION
/bin/sh: 1: /usr/src/app/download.sh: Permission denied fix

The file that the docker is trying to run is not executable and requires the `sh` command prefixed